### PR TITLE
Fixed wrong build command from farJar to fatJar.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A tool for reversing an aggregated data set into the set from which it was produ
 
 ## Building
 
-    $ gradle farJar
+    $ gradle fatJar
     
 ## Running
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-
 buildscript {
     repositories {
         mavenCentral()
@@ -38,8 +37,8 @@ eclipse {
 
 repositories {
     mavenLocal()
-    mavenCentral()
     maven { url 'http://download.osgeo.org/webdav/geotools/' }
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
Fixed build command and buildscript to avoid "Could not download artifact 'javax.media:jai_core:1.1.3:jai_core.jar'" error.
